### PR TITLE
Additional options, theory fit, hdf5 output

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -13,6 +13,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("-v", "--verbose",  dest="verbose",  default=0,  type="int",    help="Verbosity level (0 = quiet, 1 = verbose, 2+ = more)")
     parser.add_option("-m", "--mass",     dest="mass",     default=0,  type="float",  help="Higgs mass to use. Will also be written in the Workspace as RooRealVar 'MH'.")
     parser.add_option("-D", "--dataset",  dest="dataname", default="data_obs",  type="string",  help="Name of the observed dataset")
+    parser.add_option("-C", "--covariance",  dest="covname", default="data_cov",  type="string",  help="Name of the data covariance (for theory fit)")
     parser.add_option("-L", "--LoadLibrary", dest="libs",  type="string" , action="append", help="Load these libraries")
     parser.add_option("--keyword-value",     dest="modelparams",  default = [], nargs=1, type='string', action='append',  help="Set keyword values with 'WORD=VALUE', will replace $WORD with VALUE in datacards. Filename will also be extended with 'WORDVALUE' ")
     parser.add_option("--poisson",  dest="poisson",  default=0,  type="int",    help="If set to a positive number, binned datasets wih more than this number of entries will be generated using poissonians")

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -47,7 +47,7 @@ if doplotting:
 parser = OptionParser(usage="usage: %prog [options] datacard.txt -o output \nrun with --help to get list of options")
 parser.add_option("-o","--output", default=None, type="string", help="output file name")
 parser.add_option("-t","--toys", default=0, type=int, help="run a given number of toys, 0 fits the data (default), and -1 fits the asimov toy")
-parser.add_option("","--toysFrequentist", default=True, action='store_true', help="run frequentist-type toys by randomizing constraint minima")
+parser.add_option("","--toysFrequentist", default=False, action='store_true', help="run frequentist-type toys by randomizing constraint minima")
 parser.add_option("","--bypassFrequentistFit", default=True, action='store_true', help="bypass fit to data when running frequentist toys to get toys based on prefit expectations")
 parser.add_option("","--bootstrapData", default=False, action='store_true', help="throw toys directly from observed data counts rather than expectation from templates")
 parser.add_option("","--randomizeStart", default=False, action='store_true', help="randomize starting values for fit (only implemented for asimov dataset for now")
@@ -1809,7 +1809,7 @@ for itoy in range(ntoys):
       print([outname,nout,chisq])
       outchisqs.append(chisq)
       
-      if not options.toys > 0:
+      if not options.toys > 1:
         variances2D     = parameterErrors[np.newaxis].T * parameterErrors
         correlationMatrix = np.divide(invhessoutval, variances2D)
         array2hist(correlationMatrix, correlationHist)
@@ -1831,8 +1831,15 @@ for itoy in range(ntoys):
   if options.saveHists and not options.toys > 1:
     postfithists = fillHists('postfit')
     
-  if options.doImpacts and not options.toys > 0:
-    dName = 'asimov' if options.toys < 0 else 'data fit'
+  if options.doImpacts and not options.toys > 1:
+    
+    if options.toys < 0:
+      dName = 'asimov' 
+    elif options.toys > 0:
+      dName = 'toy fit'
+    else:
+      dName = 'data fit'
+
     nuisanceimpactoutvals, nuisancegroupimpactoutvals = sess.run([nuisanceimpactouts,nuisancegroupimpactouts])
     for output, outputname, nuisanceimpactoutval, nuisancegroupimpactoutval in zip(outputs,outputnames,nuisanceimpactoutvals,nuisancegroupimpactoutvals):
       outname = ":".join(output.name.split(":")[:-1])

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -93,7 +93,7 @@ if len(args) == 0:
 
 if options.chisqFit and options.theoryFit:
   raise Exception('options "--theoryFit" and "--chisqFit" cannot be simultaneously used')
-    
+
 seed = options.seed
 print(seed)
 np.random.seed(seed)
@@ -152,7 +152,7 @@ hdata_obs = f['hdata_obs']
 sparse = not 'hnorm' in f
 
 if options.theoryFit:
-  hdata_cov = f['hdata_cov']
+  hdata_cov_inv = f['hdata_cov_inv']
 
 if sparse:
   hnorm_sparse = f['hnorm_sparse']
@@ -202,7 +202,7 @@ nsystgroupsfull = len(systgroupsfull)
 constraintweights = maketensor(hconstraintweights)
 data_obs = maketensor(hdata_obs)
 if options.theoryFit:
-  data_cov = maketensor(hdata_cov)
+  data_cov_inv = maketensor(hdata_cov_inv)
 
 if options.binByBinStat:
   hkstat = f['hkstat']
@@ -444,7 +444,7 @@ lognexpnom = tf.log(nexpnomsafe)
 
 if options.theoryFit or options.chisqFit:
   residual = tf.reshape(nobs-nexp,[-1,1]) #chi2 residual
-  cov_inv = tf.matrix_inverse(data_cov) if options.theoryFit else tf.matrix_inverse(tf.diag(nobs)) # provided covariance (unfolded) or Poisson variance (detector-level)
+  cov_inv = data_cov_inv if options.theoryFit else tf.matrix_inverse(tf.diag(nobs)) # provided covariance (unfolded) or Poisson variance (detector-level)
   ln = lnfull = 0.5 * tf.reduce_sum(tf.matmul(residual,tf.matmul(cov_inv,residual),transpose_a=True))
 else: #poisson-likelihood fit
   lnfull = tf.reduce_sum(-nobs*lognexp + nexp, axis=-1) #poisson term

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -84,8 +84,8 @@ parser.add_option("","--useExpNonProfiledErrs", default=False, action='store_tru
 parser.add_option("","--yieldProtectionCutoff", default=-1., type=float, help="cutoff used to protect total yield from negative values.")
 parser.add_option("","--noHessian", default=False, action='store_true', help="Skip calculation of hessian matrix")
 parser.add_option("","--saturated", default=False, action='store_true', help="Calculate negative log likelihood value for saturated model (for using it in goodness of fit tests)")
-parser.add_option("","--externalCovariance", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
 parser.add_option("","--chisqFit", default=False, action='store_true',  help="Perform chi-square fit instead of likelihood fit")
+parser.add_option("","--externalCovariance", default=False, action='store_true',  help="Using an external covariance matrix for the observations in the chi-square fit")
 parser.add_option("","--doJacobian", default = False, action='store_true', help="Compute and store Jacobian of expected event counts with respect to fit parameters")
 (options, args) = parser.parse_args()
 

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -47,7 +47,7 @@ if doplotting:
 parser = OptionParser(usage="usage: %prog [options] datacard.txt -o output \nrun with --help to get list of options")
 parser.add_option("-o","--output", default=None, type="string", help="output file name")
 parser.add_option("-t","--toys", default=0, type=int, help="run a given number of toys, 0 fits the data (default), and -1 fits the asimov toy")
-parser.add_option("","--toysFrequentist", default=False, action='store_true', help="run frequentist-type toys by randomizing constraint minima")
+parser.add_option("","--toysBayesian", default=False, action='store_true', help="run bayesian-type toys (otherwise frequentist)")
 parser.add_option("","--bypassFrequentistFit", default=True, action='store_true', help="bypass fit to data when running frequentist toys to get toys based on prefit expectations")
 parser.add_option("","--bootstrapData", default=False, action='store_true', help="throw toys directly from observed data counts rather than expectation from templates")
 parser.add_option("","--randomizeStart", default=False, action='store_true', help="randomize starting values for fit (only implemented for asimov dataset for now")
@@ -1574,7 +1574,7 @@ if nsystnoprofile>0. and options.useExpNonProfiledErrs:
     ciexpv = sess.run(ci)
   
 #prefit to data if needed
-if options.toys>0 and options.toysFrequentist and not options.bypassFrequentistFit:  
+if options.toys>0 and not options.toysBayesian and not options.bypassFrequentistFit:  
   sess.run(dataobsassign)
   sess.run(nexpnomassign)
   minimize()
@@ -1609,7 +1609,7 @@ for itoy in range(ntoys):
     sess.run(dataobsassign)
   else:
     print("Running toy %i" % itoy)  
-    if options.toysFrequentist:
+    if not options.toysBayesian:
       #randomize nuisance constraint minima
       sess.run(frequentistassign)
     else:
@@ -1626,7 +1626,7 @@ for itoy in range(ntoys):
       
     if options.bootstrapData:
       #randomize from observed data
-      if options.binByBinStat and options.toysFrequentist:
+      if options.binByBinStat and not options.toysBayesian:
         raise Exception("Since bin-by-bin statistical uncertainties are always propagated in a bayesian manner, they cannot currently be consistently\
           propagated for bootstrap toys")
       sess.run(dataobsassign)

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -93,6 +93,8 @@ if len(args) == 0:
 
 if options.chisqFit and options.theoryFit:
   raise Exception('options "--theoryFit" and "--chisqFit" cannot be simultaneously used')
+if (options.chisqFit or options.theoryFit) and options.binByBinStat:
+  raise Exception('option "--binByBinStat" currently not supported for options "--theoryFit" and "--chisqFit"')
 
 seed = options.seed
 print(seed)

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -806,7 +806,7 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    full_cov = data_cov if not options.addMCstat else np.add(data_cov,sumw2)
+    full_cov = data_cov if not options.addMCstat else np.add(data_cov,np.diag(sumw2))
     nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -46,6 +46,7 @@ parser.add_option("", "--postfix", default="",type="string", help="add _<postfix
 parser.add_option("", "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations (all processes)")
 parser.add_option("", "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of syst variations (signal processes)")
 parser.add_option("", "--theoryFit", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
+parser.add_option("","--addMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -53,6 +54,9 @@ if len(args) == 0:
     exit(1)
 
 options.fileName = args[0]
+
+if options.addMCstat and not options.theoryFit:
+  raise Exception('options "--addMCstat" can only be used in combination with "--theoryFit"')
 
 
 if not options.fileName.endswith(".pkl"):
@@ -802,7 +806,8 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    nbytes += writeFlatInChunks(data_cov, f, "hdata_cov", maxChunkBytes = chunkSize)
+    full_cov = data_cov if not options.addMCstat else np.add(data_cov,sumw2)
+    nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 
 nbytes += writeFlatInChunks(kstat, f, "hkstat", maxChunkBytes = chunkSize)

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -46,7 +46,7 @@ parser.add_option("", "--postfix", default="",type="string", help="add _<postfix
 parser.add_option("", "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations (all processes)")
 parser.add_option("", "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of syst variations (signal processes)")
 parser.add_option("", "--theoryFit", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
-parser.add_option("","--addMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
+parser.add_option("","--noMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -55,8 +55,8 @@ if len(args) == 0:
 
 options.fileName = args[0]
 
-if options.addMCstat and not options.theoryFit:
-  raise Exception('options "--addMCstat" can only be used in combination with "--theoryFit"')
+if options.noMCstat and not options.theoryFit:
+  raise Exception('options "--noMCstat" can only be used in combination with "--theoryFit"')
 
 
 if not options.fileName.endswith(".pkl"):
@@ -806,7 +806,7 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    full_cov = data_cov if not options.addMCstat else np.add(data_cov,np.diag(sumw2))
+    full_cov = data_cov if options.noMCstat else np.add(data_cov,np.diag(sumw2))
     nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -45,8 +45,8 @@ parser.add_option("", "--scaleMaskedYields", type=float, default=1.,  help="Scal
 parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
 parser.add_option("", "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations (all processes)")
 parser.add_option("", "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of syst variations (signal processes)")
-parser.add_option("", "--externalCovariance", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
-parser.add_option("", "--addMCStat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
+parser.add_option("", "--externalCovariance", default=False, action='store_true',  help="Using an external covariance matrix for the observations in the chi-square fit")
+parser.add_option("", "--addMCStat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with --externalCovariance only)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:


### PR DESCRIPTION
Two options are added:
- option to skip hessian calculation
- option to calculate the nll of the saturated model and save it in the fitresults
- Make writing hdf5 output files default; additional information is added (e.g. impact histograms which can become too large for root); Meta data is passed through combinetf.

on top of #20 