### PR TITLE
Implementation of chi2 fit

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -13,6 +13,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("-v", "--verbose",  dest="verbose",  default=0,  type="int",    help="Verbosity level (0 = quiet, 1 = verbose, 2+ = more)")
     parser.add_option("-m", "--mass",     dest="mass",     default=0,  type="float",  help="Higgs mass to use. Will also be written in the Workspace as RooRealVar 'MH'.")
     parser.add_option("-D", "--dataset",  dest="dataname", default="data_obs",  type="string",  help="Name of the observed dataset")
+    parser.add_option("-C", "--covariance",  dest="covname", default="data_cov",  type="string",  help="Name of the data covariance (for theory fit)")
     parser.add_option("-L", "--LoadLibrary", dest="libs",  type="string" , action="append", help="Load these libraries")
     parser.add_option("--keyword-value",     dest="modelparams",  default = [], nargs=1, type='string', action='append',  help="Set keyword values with 'WORD=VALUE', will replace $WORD with VALUE in datacards. Filename will also be extended with 'WORDVALUE' ")
     parser.add_option("--poisson",  dest="poisson",  default=0,  type="int",    help="If set to a positive number, binned datasets wih more than this number of entries will be generated using poissonians")

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -93,7 +93,7 @@ if len(args) == 0:
 
 if options.chisqFit and options.theoryFit:
   raise Exception('options "--theoryFit" and "--chisqFit" cannot be simultaneously used')
-    
+
 seed = options.seed
 print(seed)
 np.random.seed(seed)
@@ -152,7 +152,7 @@ hdata_obs = f['hdata_obs']
 sparse = not 'hnorm' in f
 
 if options.theoryFit:
-  hdata_cov = f['hdata_cov']
+  hdata_cov_inv = f['hdata_cov_inv']
 
 if sparse:
   hnorm_sparse = f['hnorm_sparse']
@@ -202,7 +202,7 @@ nsystgroupsfull = len(systgroupsfull)
 constraintweights = maketensor(hconstraintweights)
 data_obs = maketensor(hdata_obs)
 if options.theoryFit:
-  data_cov = maketensor(hdata_cov)
+  data_cov_inv = maketensor(hdata_cov_inv)
 
 if options.binByBinStat:
   hkstat = f['hkstat']
@@ -444,7 +444,7 @@ lognexpnom = tf.log(nexpnomsafe)
 
 if options.theoryFit or options.chisqFit:
   residual = tf.reshape(nobs-nexp,[-1,1]) #chi2 residual
-  cov_inv = tf.matrix_inverse(data_cov) if options.theoryFit else tf.matrix_inverse(tf.diag(nobs)) # provided covariance (unfolded) or Poisson variance (detector-level)
+  cov_inv = data_cov_inv if options.theoryFit else tf.matrix_inverse(tf.diag(nobs)) # provided covariance (unfolded) or Poisson variance (detector-level)
   ln = lnfull = 0.5 * tf.reduce_sum(tf.matmul(residual,tf.matmul(cov_inv,residual),transpose_a=True))
 else: #poisson-likelihood fit
   lnfull = tf.reduce_sum(-nobs*lognexp + nexp, axis=-1) #poisson term

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -93,6 +93,8 @@ if len(args) == 0:
 
 if options.chisqFit and options.theoryFit:
   raise Exception('options "--theoryFit" and "--chisqFit" cannot be simultaneously used')
+if (options.chisqFit or options.theoryFit) and options.binByBinStat:
+  raise Exception('option "--binByBinStat" currently not supported for options "--theoryFit" and "--chisqFit"')
 
 seed = options.seed
 print(seed)

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -806,7 +806,7 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    full_cov = data_cov if not options.addMCstat else np.add(data_cov,sumw2)
+    full_cov = data_cov if not options.addMCstat else np.add(data_cov,np.diag(sumw2))
     nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -46,6 +46,7 @@ parser.add_option("", "--postfix", default="",type="string", help="add _<postfix
 parser.add_option("", "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations (all processes)")
 parser.add_option("", "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of syst variations (signal processes)")
 parser.add_option("", "--theoryFit", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
+parser.add_option("","--addMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -53,6 +54,9 @@ if len(args) == 0:
     exit(1)
 
 options.fileName = args[0]
+
+if options.addMCstat and not options.theoryFit:
+  raise Exception('options "--addMCstat" can only be used in combination with "--theoryFit"')
 
 
 if not options.fileName.endswith(".pkl"):
@@ -802,7 +806,8 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    nbytes += writeFlatInChunks(data_cov, f, "hdata_cov", maxChunkBytes = chunkSize)
+    full_cov = data_cov if not options.addMCstat else np.add(data_cov,sumw2)
+    nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 
 nbytes += writeFlatInChunks(kstat, f, "hkstat", maxChunkBytes = chunkSize)

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -46,7 +46,7 @@ parser.add_option("", "--postfix", default="",type="string", help="add _<postfix
 parser.add_option("", "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations (all processes)")
 parser.add_option("", "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of syst variations (signal processes)")
 parser.add_option("", "--theoryFit", default=False, action='store_true',  help="Fit theory to unfolded cross section (e.g. mW extraction)")
-parser.add_option("","--addMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
+parser.add_option("","--noMCstat", default=False, action='store_true', help="add MC stat uncertainty to covariance matrix (compatible with theory fit only)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -55,8 +55,8 @@ if len(args) == 0:
 
 options.fileName = args[0]
 
-if options.addMCstat and not options.theoryFit:
-  raise Exception('options "--addMCstat" can only be used in combination with "--theoryFit"')
+if options.noMCstat and not options.theoryFit:
+  raise Exception('options "--noMCstat" can only be used in combination with "--theoryFit"')
 
 
 if not options.fileName.endswith(".pkl"):
@@ -806,7 +806,7 @@ nbytes += writeFlatInChunks(data_obs, f, "hdata_obs", maxChunkBytes = chunkSize)
 data_obs = None
 
 if options.theoryFit:
-    full_cov = data_cov if not options.addMCstat else np.add(data_cov,np.diag(sumw2))
+    full_cov = data_cov if options.noMCstat else np.add(data_cov,np.diag(sumw2))
     nbytes += writeFlatInChunks(np.linalg.inv(full_cov), f, "hdata_cov_inv", maxChunkBytes = chunkSize)
     data_cov = None
 


### PR DESCRIPTION
- the option `--theoryFit` adds functionalities to read-in/write-out the covariance matrix (text2hdf5) and to use it in a chi2 fit of a theory prediction to unfolded data (combinetf)
- in combinetf, I also added an option `--chisqFit` that performs a chi2 fit at detector level, with a diagonal covariance obtained from the Poisson variance of the data